### PR TITLE
**Updated:** Bump Version in Manifest file to 0.9 (Current Version in VS Gallery is 0.8)

### DIFF
--- a/VarTypeViewer/source.extension.vsixmanifest
+++ b/VarTypeViewer/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="Srt2VarTypeViewerVsix" Version="0.6" Language="en-US" Publisher="SRT2" />
+    <Identity Id="Srt2VarTypeViewerVsix" Version="0.9" Language="en-US" Publisher="SRT2" />
     <DisplayName>VarTypeViewer.Vsix</DisplayName>
     <Description>VarTypeViewer.</Description>
   </Metadata>


### PR DESCRIPTION
Raised from @KoalaBear84's issue [here](https://github.com/jonkeda/VarTypeViewer/issues/1#issuecomment-675443805) regarding the manifest Version Number needing updated.